### PR TITLE
MessageDispatcher: fix Callback class not working properly on OpenFL's flash/air targets

### DIFF
--- a/src/robotlegs/bender/framework/impl/MessageDispatcher.hx
+++ b/src/robotlegs/bender/framework/impl/MessageDispatcher.hx
@@ -178,6 +178,26 @@ class Callback {
 	public var length:Int = 0;
 
 	public function new(value:Dynamic) {
+		#if flash
+		length = Reflect.field(value, "length");
+		call = (v1:Dynamic, v2:Dynamic) -> {
+			if (length == 0) {
+				var func0:Void->Void = value;
+				func0();
+			}
+			else if (length == 1) {
+				var func1:Dynamic->Void = value;
+				func1(v1);
+			}
+			else if (length == 2) {
+				var func2:Dynamic->Dynamic->Void = value;
+				func2(v1, v2);
+			}
+			else {
+				throw "Bad handler signature";
+			}
+		}
+		#else
 		var func0:Void->Void = null;
 		try {
 			func0 = value;
@@ -207,5 +227,6 @@ class Callback {
 				}
 			}
 		}
+		#end
 	}
 }


### PR DESCRIPTION
On those targets, no exceptions are thrown until the function is called, but that's too late because the length was already incorrectly detected as 0.

Robotlegs doesn't seem to work at all on OpenFL's flash/air targets without this fix.